### PR TITLE
Add 'aggressive' option to work around wrapped quoted text

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,16 @@ var email = replyParser(emailContent);
 * `getFragments()`: returns all the fragments of the email
 * `getVisibleText()`: returns the text that is considered 'visible'
 
+`getVisibleText()` accepts an optional options object:
+
+```
+getVisibleText({aggressive: true})
+```
+
+Setting `aggressive` to true will make the parser assume that any fragment which is not hidden, but which is both preceded and followed by a hidden fragment, should not be visible. This works around the issue of clients breaking quoted text into multiple lines (e.g. Gmail). 
+
+Using aggressive mode runs the risk of losing visible lines which are interspersed with quoted lines, but is useful when parsing e.g. emails from a 'reply by email' feature which contain a large block of quoted text.
+
 A fragment has the following functions:
 * `getContent()`: returns the content of the fragment
 * `isSignature()`: returns whether or not the fragment is likely a signature

--- a/lib/Email.js
+++ b/lib/Email.js
@@ -33,8 +33,24 @@ class Email {
      * Gets a string that represents the visible text of this Email
      * @returns {string} the visible text
      */
-    getVisibleText() {
-        var visibleFragments = filter(this._fragments, f => !f.isHidden());
+    getVisibleText(options = {}) {
+        var visibleFragments;
+
+        if (options.aggressive === true) {            
+           
+            visibleFragments = filter(this._fragments, (f, index) => {
+                if (this._fragments[index - 1] 
+                    && this._fragments[index + 1] 
+                    && this._fragments[index - 1].isHidden() 
+                    && this._fragments[index + 1].isHidden()) {
+                    return false;
+                }
+                return !f.isHidden();                
+            });        
+
+        } else {
+            visibleFragments = filter(this._fragments, f => !f.isHidden());
+        }
         var fragmentBodies = map(visibleFragments, f => f.getContent());
         return fragmentBodies.join("\n");
     }


### PR DESCRIPTION
Added an option to aggressively prune fragments that are both preceded and followed by hidden fragments, and therefore should potentially be hidden themselves. This works around the issue of Gmail wrapping quoted text to 80 columns.