### PR TITLE
Add index.d.ts to npm packaged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "LICENSE",
     "README.md",
     "index.js",
+    "index.d.ts",
     "lib/"
   ],
   "types": "index.d.ts",


### PR DESCRIPTION
The repo contains index.d.ts but the NPM package does not because the file is not in the "files" directive in package.json. This PR fixes that problem. 

* The `develop` branch does not include the `index.d.ts` file at all, so I am applying to `master`, which appears to be the basis for the 0.1.1 release. if I am in error, glad to correct - just want this to be useful for TS devs! 