### PR TITLE
Support no empty line before quote header

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -128,7 +128,7 @@ class Parser {
                     this._addFragment(fragment, fragments);
 
                     fragment = null;
-                } else if (line.length === 0 && this._isQuoteHeader(lastLine)) {
+                } else if (this._isQuoteHeader(lastLine)) {
                     fragment.isQuoted = true;
                     this._addFragment(fragment, fragments);
 

--- a/test/ParserTest.js
+++ b/test/ParserTest.js
@@ -449,6 +449,17 @@ describe('the Parser', function () {
         assert.equal(/Was this/.test(fragments[1].getContent()), true, "Second fragment has wrong content");
     });
 
+    it('should parse an email where the quote header does not have a preceeding empty line', function () {
+        var parser = new Parser();
+        var fixture = util.getFixture("email_quote_header_without_new_line.txt");
+        var email = parser.parse(fixture);
+        var fragments = email.getFragments();
+
+        assert.equal(/^ Gran Via, 1, 28004, Madrid$/.test(email.getVisibleText()), true)
+        assert.equal(/^ Gran Via, 1, 28004, Madrid/.test(fragments[0].getContent()), true, "First fragment has wrong content");
+        assert.equal(/^    On Wednesday, 23 February 2022/.test(fragments[1].getContent()), true, "Second fragment has wrong content");
+    });
+
     it('should parse visible text that looks like a quote header (second)', function () {
         var parser = new Parser();
         var fixture = util.getFixture("email_20.txt");

--- a/test/fixtures/email_quote_header_without_new_line.txt
+++ b/test/fixtures/email_quote_header_without_new_line.txt
@@ -1,0 +1,8 @@
+
+ Gran Via, 1, 28004, Madrid
+    On Wednesday, 23 February 2022, 14:46:52 CET, Alicia
+ <alicia@example.com> wrote:
+
+ Hello,
+May I get your postal address?
+Thanks


### PR DESCRIPTION
Hello! Thanks for the great library!

While doing some tests this week using different email providers, `node-email-reply-parser` failed to successfully parse some of our emails' contents. Specifically, email replies coming from yahoo.com where the 'quote header' (`On Feb,....wrote:`) does not have any preceding empty line.

Yahoo will not add a new line unless you specifically do it in the email editor.

Unless there's any reason why we should expect a new line, always, I think the fix we're proposing here is correct. All tests pass.

The contents of the email contain lots of additional white spacing and we don't trim it in the test. This has been extracted straight from a raw yahoo.com email and we have not modified so it actually reflects what yahoo (in this case) generates as the email's plain text part.