### PR TITLE
Spanish icloud support

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -28,7 +28,7 @@ const QUOTE_REGEX = />+$/;
 const QUOTE_HEADERS_REGEX = [
     /^\s*(On(?:(?!.*On\b|\bwrote:)[\s\S])+wrote:)$/m, // On DATE, NAME <EMAIL> wrote:
     /^\s*(Le(?:(?!.*Le\b|\bécrit:)[\s\S])+écrit(\s|\xc2\xa0):)$/m, // On DATE, NAME <EMAIL> wrote:
-    /^\s*(El(?:(?!.*El\b|\bescribió:)[\s\S])+escribió:)$/m, // On DATE, NAME <EMAIL> wrote:
+    /^\s*(El(?:(?!.*El\b|\bescribió:)[\s\S])+escribi(ó|eron):)$/m, // On DATE, NAME <EMAIL> wrote:
     /^\s*(Il(?:(?!.*Il\b|\bscritto:)[\s\S])+scritto:)$/m, // On DATE, NAME <EMAIL> wrote:
     /^\s*(Op\s[\S\s]+?(schreef|geschreven)[\S\s]+:)$/m, // Op DATE schreef NAME <EMAIL>:, Op DATE heeft NAME <EMAIL> het volgende geschreven:
     /^\s*(Em(?:(?!.*Em\b|\bescreveu:)[\s\S])+escreveu:)$/m, // Em DATE, NAME <EMAIL> escreveu:

--- a/test/ParserTest.js
+++ b/test/ParserTest.js
@@ -23,6 +23,7 @@ const DATE_FORMATS = [
     '2014-03-09 20:48 GMT+01:00 Rémi Dolan <do_not_reply@dolan.com>:', // Gmail
     'Le 19 mars 2014 10:37, Cédric Lombardot <cedric.lombardot@gmail.com> a écrit :', // Gmail
     'El 19/03/2014 11:34, Juan Pérez <juan.perez@mailcatch.com> escribió:', // Gmail in spanish
+    'El 19/03/2014 11:34, Juan Pérez <juan.perez@mailcatch.com> escribieron:', // iCloud in spanish
     'Em ter., 01 de mar. de 2011 às 18:02, Abhishek <juan.perez@mailcatch.com> escreveu:', // Gmail in PT-BR
     'W dniu 7 stycznia 2015 15:24 użytkownik Paweł Brzoski <pbrzoski91@gmail.com> napisał:', //Gmail in polish
     'Le 19/03/2014 11:34, Georges du chemin a écrit :', // Thunderbird


### PR DESCRIPTION
Tiny one: iCloud uses the past tense in plural first person when replying to emails.