### PR TITLE
Support for visible quoted blocks

### DIFF
--- a/lib/Fragment.js
+++ b/lib/Fragment.js
@@ -49,7 +49,7 @@ class Fragment {
     }
 
     /**
-     * Gets whether or not this is a quoted element
+     * Gets whether this is a quoted element
      * @returns {boolean} true if this is a quoted element, false otherwise
      */
     isQuoted() {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -169,8 +169,12 @@ class Parser {
      * @private
      */
     _addFragment(fragment, collection) {
-        if (fragment.isQuoted || fragment.isSignature || fragment.lines.join('').length === 0) {
-            fragment.isHidden = true;
+        if (fragment.isSignature || fragment.lines.join('').length === 0) {
+            fragment.isHidden = true
+        } else if (fragment.isQuoted && fragment.lines.filter(line=>this._isQuoteHeader(line)).length===0) {
+            fragment.isHidden = false
+        } else if (fragment.isQuoted) {
+            fragment.isHidden = true
         }
 
         collection.push(fragment);

--- a/test/ParserTest.js
+++ b/test/ParserTest.js
@@ -439,6 +439,24 @@ describe('the Parser', function () {
         assert.equal(fragments[1].isQuoted(), true, "Second fragment should be quoted");
     });
 
+    it('should parse an email containing **visible** quoted text', function () {
+        var parser = new Parser();
+        var fixture = util.getFixture("email_with_quoted_text.txt");
+        var email = parser.parse(fixture);
+        var visibleText = email.getVisibleText();
+        var fragments = email.getFragments();
+
+        var expectedText = `here you go:
+> const x = 1;
+what do you think?
+`
+        assert.equal(visibleText, expectedText, "The visible content is not right");
+        assert.equal(/^here you go:$/.test(fragments[0].getContent()), true, "First fragment has wrong content");
+        assert.equal(/^> const x = 1;$/.test(fragments[1].getContent()), true, "Second fragment has wrong content");
+        assert.equal(/^what do you think?/.test(fragments[2].getContent()), true, "Third fragment has wrong content");
+        assert.equal(/good morning, sure why not/.test(fragments[3].getContent()), true, "Fourth fragment has wrong content");
+    });
+
     it('should parse visible text that looks like a quote header', function () {
         var parser = new Parser();
         var fixture = util.getFixture("email_19.txt");
@@ -450,7 +468,7 @@ describe('the Parser', function () {
         assert.equal(/Was this/.test(fragments[1].getContent()), true, "Second fragment has wrong content");
     });
 
-    it('should parse an email where the quote header does not have a preceeding empty line', function () {
+    it('should parse an email where the quote header does not have a preceding empty line', function () {
         var parser = new Parser();
         var fixture = util.getFixture("email_quote_header_without_new_line.txt");
         var email = parser.parse(fixture);

--- a/test/fixtures/email_with_quoted_text.txt
+++ b/test/fixtures/email_with_quoted_text.txt
@@ -1,0 +1,14 @@
+here you go:
+
+> const x = 1;
+
+what do you think?
+
+On Wed, 15 Jun 2022 at 17:06, Pete <pete@example.com> wrote:
+
+> good morning, sure why not
+>
+>
+> On Wed, 15 Jun 2022 at 17:05, Mike <mike@example.com> wrote:
+>
+> > hey, do you still want to see my code?


### PR DESCRIPTION
Hello again @turt2live ! Thanks for merging the other two PRs. We recently stopped using our fork because of that 👍 

This time I'm adding support for *visible* 'quoted' text. By default, all quoted text is hidden. However, it should only be hidden if it's part of a reply. If it's not, it means we're in the visible content part of the email and that should have `.isHidden=false`.

I've done this by modifying how the hidden flag gets set when adding a new fragment. At that point we've got all of the text in the fragment, so I check whether any of the lines is a quote header. If it is, this fragment should be hidden. Otherwise, it should not.